### PR TITLE
Fix Evergreen Needleleaf Forests typo

### DIFF
--- a/dfc_dataset.py
+++ b/dfc_dataset.py
@@ -16,7 +16,7 @@ from utils import AlbumentationsToTorchTransform
 from dfc_sen12ms_dataset import DFCSEN12MSDataset, Seasons, S1Bands, S2Bands, LCBands
 
 IGBP_map = {
-    1: "Evergreen Needleleaf FOrests",
+    1: "Evergreen Needleleaf Forests",
     2: "Evergreen Broadleaf Forests",
     3: "Deciduous Needleleaf Forests",
     4: "Deciduous Broadleaf Forests",


### PR DESCRIPTION
## Summary
- fix spelling of "Evergreen Needleleaf Forests" in the `IGBP_map` lookup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fef22d2fc832a9cb6a73bcad731d0