### PR TITLE
Fix pixelwise metrics when class absent

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -157,9 +157,13 @@ class PixelwiseMetrics(object):
             class_data = self.data["pixelclass_" + str(c)]
             preds_c = y_hat == c
             targs_c = y == c
-            num_correct = (preds_c * targs_c).sum().cpu().detach().numpy()
             num_pixels = np.sum(targs_c.cpu().detach().numpy())
-            class_data["acc"] += num_correct / num_pixels
+
+            if num_pixels > 0:
+                num_correct = (
+                    preds_c * targs_c
+                ).sum().cpu().detach().numpy()
+                class_data["acc"] += num_correct / num_pixels
 
     def get_classwise_accuracy(self):
         return {k: el['acc'] / self.count for k, el in self.data.items()}


### PR DESCRIPTION
## Summary
- avoid divide by zero in `PixelwiseMetrics.add_batch`

## Testing
- `python -m py_compile metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_683fef24006c832ab8bd51c1d02a0620