### PR TITLE
Fix inconsistent default path docstring

### DIFF
--- a/searcher.py
+++ b/searcher.py
@@ -11,7 +11,8 @@ def get_patches_within_bbox(ne_corner: Tuple[float, float], sw_corner: Tuple[flo
     Parameters:
     - ne_corner (Tuple[float, float]): Northeast corner of bounding box.
     - sw_corner (Tuple[float, float]): Southwest corner of bounding box.
-    - folder_path (str): Directory where the raster files are stored. Default is 'output'.
+    - folder_path (str): Directory where the raster files are stored. Default is
+      'Patch_Cropper/patches_test'.
     
     Returns:
     List[str]: List of matching raster files.


### PR DESCRIPTION
## Summary
- correct the default folder path in `get_patches_within_bbox` docstring

## Testing
- `python -m py_compile searcher.py`


------
https://chatgpt.com/codex/tasks/task_e_683fef246d38832a8cbe7d7b57f42a95